### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/src/runtime/composables/index.ts
+++ b/src/runtime/composables/index.ts
@@ -7,7 +7,7 @@ import { Hanko } from '@teamhanko/hanko-elements'
  * It will be `null` on the server but defined on the client.
  */
 export function useHanko() {
-  if (process.server) {
+  if (import.meta.server) {
     return null
   }
 

--- a/src/runtime/middleware/logged-in.ts
+++ b/src/runtime/middleware/logged-in.ts
@@ -11,7 +11,7 @@ import {
 export default defineNuxtRouteMiddleware(async to => {
   const redirects = useAppConfig().hanko.redirects
 
-  if (process.server) {
+  if (import.meta.server) {
     const event = useRequestEvent()
 
     if (!event.context.hanko?.sub && to.path !== redirects.login) {

--- a/src/runtime/middleware/logged-out.ts
+++ b/src/runtime/middleware/logged-out.ts
@@ -10,7 +10,7 @@ import {
 export default defineNuxtRouteMiddleware(async to => {
   const redirects = useAppConfig().hanko.redirects
 
-  if (process.server) {
+  if (import.meta.server) {
     const event = useRequestEvent()
 
     if (event.context.hanko?.sub && to.path !== redirects.home) {


### PR DESCRIPTION
This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).