### PR TITLE
fix: use fully-resolved template path in hanko alias

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -99,7 +99,7 @@ export default defineNuxtModule<ModuleOptions>({
       imports: ['useHanko'],
     })
 
-    addTemplate({
+    const hankoElementsTemplate = addTemplate({
       filename: 'hanko-elements.mjs',
       getContents: () => `export const Hanko = () => null`,
     })
@@ -107,7 +107,7 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.hook('vite:extendConfig', (config, { isServer }) => {
       if (isServer) {
         config.resolve!.alias = defu(config.resolve!.alias, {
-          '@teamhanko/hanko-elements': '#build/hanko-elements',
+          '@teamhanko/hanko-elements': hankoElementsTemplate.dst,
         })
       }
     })


### PR DESCRIPTION
Closes #112 

The `addTemplate` function in combination with accessing via `#builds/hanko-elements` seems to be broken.
Accessing the `dst` attribute of the returned `ResolvedNuxtTemplate` fixes this issue. 