### PR TITLE
Add types to Hanko JWT

### DIFF
--- a/src/runtime/auth.d.ts
+++ b/src/runtime/auth.d.ts
@@ -1,7 +1,19 @@
 import type { JWTPayload } from 'jose'
 
+export type HankoPayload = JWTPayload & {
+  aud: string[]
+  email: {
+    address: string
+    is_primary: boolean
+    is_verified: boolean
+  }
+  exp: number
+  iat: number
+  sub: string
+}
+
 declare module 'h3' {
   interface H3EventContext {
-    hanko?: JWTPayload
+    hanko?: HankoPayload
   }
 }

--- a/src/runtime/server/utils/index.ts
+++ b/src/runtime/server/utils/index.ts
@@ -1,8 +1,8 @@
 import type { H3Event } from 'h3'
 import { createError, getCookie, getHeader } from 'h3'
 import { createRemoteJWKSet, jwtVerify } from 'jose'
-import { useRuntimeConfig } from '#imports'
 import type { HankoPayload } from '../../auth'
+import { useRuntimeConfig } from '#imports'
 
 export async function verifyHankoEvent(event: H3Event) {
   const hankoConfig = useRuntimeConfig().public.hanko

--- a/src/runtime/server/utils/index.ts
+++ b/src/runtime/server/utils/index.ts
@@ -2,6 +2,7 @@ import type { H3Event } from 'h3'
 import { createError, getCookie, getHeader } from 'h3'
 import { createRemoteJWKSet, jwtVerify } from 'jose'
 import { useRuntimeConfig } from '#imports'
+import type { HankoPayload } from '../../auth'
 
 export async function verifyHankoEvent(event: H3Event) {
   const hankoConfig = useRuntimeConfig().public.hanko
@@ -17,5 +18,5 @@ export async function verifyHankoEvent(event: H3Event) {
     })
   }
 
-  return await jwtVerify(jwt, JWKS).then(r => r.payload)
+  return await jwtVerify<HankoPayload>(jwt, JWKS).then(r => r.payload)
 }


### PR DESCRIPTION
relates to #2 

Adds types to Hanko JWT, specifically the `verifyHankoEvent` function.

If wanted, I'll add validation to the types. I'd just need to know what the expected behaviour is if the JWT does not contain the expected information.